### PR TITLE
hotfix: add checking 'undefined' in _pluginWeb.js

### DIFF
--- a/lib/_pluginWeb.js
+++ b/lib/_pluginWeb.js
@@ -17,6 +17,7 @@ self.connection = {};
      */
     self.addEventListener('message', function(e){
         var m = e.data.data;
+        if (typeof m == 'undefined') return;
         switch (m.type) {
         case 'import':
         case 'importJailed':  // already jailed in the Worker


### PR DESCRIPTION
Hello.
Thank you for your kindness earlier in #9 .

After that. I continued to find how to install jailed properly in my meteor project.
In server side of meteor, It was easy with [/meteorhacks/npm](https://atmospherejs.com/meteorhacks/npm).
In client side of meteor, It was not easy.

Finally, I succeed at it with [meteor-bower](https://github.com/mquandalle/meteor-bower).
But, I needed a bit tweak on jailed source code.

So it is this pull request.
I'm not sure that this check code is appropriate for your code design.
But unless this checking, the `switch (m.type) statement` cause error at initialization of app.

![error_at_initialization](https://cloud.githubusercontent.com/assets/3821214/8771683/67d72a5e-2eff-11e5-8752-1d9509bd348d.jpg)

Please consider my proposal.