### PR TITLE
Add chrome https fallback

### DIFF
--- a/lib/_frame2.html
+++ b/lib/_frame2.html
@@ -1,0 +1,1 @@
+<script src="_frame2.js"></script>

--- a/lib/_frame2.js
+++ b/lib/_frame2.js
@@ -14,21 +14,8 @@ var __jailed__path__ = scripts[scripts.length-1].src
     .slice(0, -1)
     .join('/')+'/';
 
-// creating worker as a blob enables import of local files
-var blobCode = [
-  ' self.addEventListener("message", function(m){          ',
-  '     if (m.data.type == "initImport") {                 ',
-  '         importScripts(m.data.url);                     ',
-  '         self.postMessage({type: "initialized"});       ',
-  '     }                                                  ',
-  ' });                                                    '
-].join('\n');
-
-var blobUrl = window.URL.createObjectURL(
-    new Blob([blobCode])
-);
-
-var worker = new Worker(blobUrl);
+var normalUrl = __jailed__path__ + "_worker.js";
+var worker = new Worker(normalUrl);
 
 // telling worker to load _pluginWeb.js (see blob code above)
 worker.postMessage({

--- a/lib/_worker.js
+++ b/lib/_worker.js
@@ -1,0 +1,6 @@
+self.addEventListener("message", function(m){
+    if (m.data.type == "initImport") {
+        importScripts(m.data.url);
+        self.postMessage({type: "initialized"});
+    }
+});

--- a/lib/jailed.js
+++ b/lib/jailed.js
@@ -201,25 +201,6 @@ if (typeof window == 'undefined') {
             this._disconnected = false;
             this._messageHandler = function(){};
             this._disconnectHandler = function(){};
-            
-/*            
-var child = require('child_process');
-var debug = process.execArgv.indexOf('--debug') !== -1;
-if(debug) {   
-    //Set an unused port number.    
-    process.execArgv.push('--debug=' + (40894));    
-}    
-child.fork(__dirname + '/task.js');
-*/
-
-
-var debug = process.execArgv.indexOf('--debug-brk') !== -1;
-if(debug) {
-    console.log("DEBUG");
-    process.execArgv.push('--debug-brk=' + 40894);
-}
-
-
             this._process = childProcess.fork(
                 __jailed__path__+'_pluginNode.js'
             );
@@ -337,10 +318,14 @@ if(debug) {
             platformInit.whenEmitted(function() {
                 if (!me._disconnected) {
                     me._frame = sample.cloneNode(false);
+                    if(jailed._chromeHttpsWorkaround){
+                        me._frame.sandbox = 'allow-scripts allow-same-origin';
+                        me._frame.src = __jailed__path__ + '_frame2.html';
+                    }
                     document.body.appendChild(me._frame);
 
                     window.addEventListener('message', function (e) {
-                        if (e.origin === "null" &&
+                        if ((e.origin === "null" || jailed._chromeHttpsWorkaround) &&
                             e.source === me._frame.contentWindow) {
                             if (e.data.type == 'initialized') {
                                 me._init.emit();
@@ -794,6 +779,10 @@ if(debug) {
     
     exports.Plugin = Plugin;
     exports.DynamicPlugin = DynamicPlugin;
-  
+    
+    exports._chromeHttpsWorkaround = false;
+    exports.setChromeHttpsWorkaroundOn = function(flag){
+        this._chromeHttpsWorkaround = flag;
+    };
 }));
 


### PR DESCRIPTION
I've added a function `jailed.setChromeHttpsWorkaroundOn(boolean)` that makes jailed use a workaround to avoid the [error chrome gives on https](https://github.com/asvd/jailed/issues/7).

Enabling the workaround gives the jailed script access to origin things such as indexedDB and ajax, so be careful if using it