### PR TITLE
fixed Node-detection

### DIFF
--- a/lib/jailed.js
+++ b/lib/jailed.js
@@ -44,7 +44,8 @@ if (typeof window == 'undefined') {
         factory((root.jailed = {}));
     }
 }(this, function (exports) {
-    var isNode = typeof window == 'undefined';
+    var isNode = ((typeof process !== 'undefined') &&
+                  (process.release.name.search(/node|io.js/) !== -1));
       
 
     /**


### PR DESCRIPTION
The previous implementation was depending on the window-property which is at least in the Electron-environment available although the javascript is running in a Node-process.

The new detection-statement relies on the [`process.release`](https://nodejs.org/api/process.html#process_process_release)-object which allows the safe identification of node.js and io.js.

P.s.: I didn't open an issue since it seems to be an atomic change. I hope filing immediately a PR is not considered as rude behaviour.

:beers: 