### PR TITLE
Add webpack support

### DIFF
--- a/lib/jailed.js
+++ b/lib/jailed.js
@@ -45,8 +45,8 @@ if (typeof window == 'undefined') {
     }
 }(this, function (exports) {
     var isNode = ((typeof process !== 'undefined') &&
+                  (!process.browser) &&
                   (process.release.name.search(/node|io.js/) !== -1));
-      
 
     /**
      * A special kind of event:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "type": "git",
     "url": "git://github.com/asvd/jailed.git"
   },
+  "browser":
+    {
+      "fs": false,
+      "child_process": false
+    },
   "main": "lib/jailed.js",
   "dependencies": {},
   "devDependencies": {},


### PR DESCRIPTION
This adds Webpack support.
There are two faces of this:

1 - Add the `browser` entry to `package.json`, as described in https://github.com/asvd/jailed/issues/22
2 - `jailed.js` fails with latest Webpacks, because the process variable is defined. I added another test to check if `process.browser` is false, before we decide we are on Node.