### PR TITLE
Extend the node detection fix of florianb.

### DIFF
--- a/lib/jailed.js
+++ b/lib/jailed.js
@@ -21,7 +21,10 @@
 
 
 var __jailed__path__;
-if (typeof window == 'undefined') {
+var __is__node__ = ((typeof process !== 'undefined') &&
+                    (!process.browser) &&
+                    (process.release.name.search(/node|io.js/) !== -1));
+if (__is__node__) {
     // Node.js
     __jailed__path__ = __dirname + '/';
 } else {
@@ -44,10 +47,6 @@ if (typeof window == 'undefined') {
         factory((root.jailed = {}));
     }
 }(this, function (exports) {
-    var isNode = ((typeof process !== 'undefined') &&
-                  (!process.browser) &&
-                  (process.release.name.search(/node|io.js/) !== -1));
-
     /**
      * A special kind of event:
      *  - which can only be emitted once;
@@ -403,7 +402,7 @@ if (typeof window == 'undefined') {
     }
 
 
-    if (isNode) {
+    if (__is__node__) {
         initNode();
         basicConnectionNode();
     } else {

--- a/tests/lighttest.js
+++ b/tests/lighttest.js
@@ -33,10 +33,13 @@
      */
     lighttest._platform.init = function () {
         if (!lighttest._platform._initialized) {
-            if (typeof window != 'undefined') {
-                lighttest._platform._initWeb();
-            } else {
+            var __is__node__ = ((typeof process !== 'undefined') &&
+                                (!process.browser) &&
+                                (process.release.name.search(/node|io.js/) !== -1));
+            if (__is__node__) {
                 lighttest._platform._initNode();
+            } else {
+                lighttest._platform._initWeb();
             }
             lighttest._platform._initialized = true;
         }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,4 +1,6 @@
-var isNode = typeof window == 'undefined';
+var __is__node__ = ((typeof process !== 'undefined') &&
+                    (!process.browser) &&
+                    (process.release.name.search(/node|io.js/) !== -1));
 var currentPath;
 
 var whenFailed = function(){
@@ -6,7 +8,7 @@ var whenFailed = function(){
     lighttest.done();
 }
 
-if (isNode) {
+if (__is__node__) {
     currentPath = __dirname + '/';
 } else {
     var scripts = document.getElementsByTagName('script');


### PR DESCRIPTION
`__jailed__path__` is defined depending on whether the environment is
Node or a browser. The earlier node detection fix was not applied to the
code that controlled how `__jailed__path__` was populated.

See #25 for original node detection fix.