### PR TITLE
Gets the correct address for the current script on browsers

### DIFF
--- a/lib/jailed.js
+++ b/lib/jailed.js
@@ -29,12 +29,22 @@ if (__is__node__) {
     __jailed__path__ = __dirname + '/';
 } else {
     // web
-    var scripts = document.getElementsByTagName('script');
-    __jailed__path__ = scripts[scripts.length-1].src
-        .split('?')[0]
-        .split('/')
-        .slice(0, -1)
-        .join('/')+'/';
+    if (doucment.currentScript) {
+        var script = document.currentScript;
+        __jailed__path__ = script.src
+            .split('?')[0]
+            .split('/')
+            .slice(0, -1)
+            .join('/')+'/';
+    } else {
+        // for legacy browsers and IE
+        var scripts = document.getElementsByTagName('script');
+        __jailed__path__ = scripts[scripts.length-1].src
+            .split('?')[0]
+            .split('/')
+            .slice(0, -1)
+            .join('/')+'/';
+    }
 }
 
 


### PR DESCRIPTION
The old way breaks if you load the script using html imports

Then the url is pointing at an invalid script.